### PR TITLE
[refactor] gemini code assist 제안 기반 타입, 메서드, 쿼리키 리팩토링

### DIFF
--- a/frontend/actions/upbit/getAllTickers.ts
+++ b/frontend/actions/upbit/getAllTickers.ts
@@ -4,21 +4,6 @@ import { IUpbitMarket } from '@/types/upbit/market';
 import { ITicker } from '@/types/upbit/ticker';
 import Upbit from '@/lib/api/upbit';
 
-// REST API 응답용 타입 (market 필드 사용)
-interface IUpbitRestTicker {
-    market: string;
-    trade_price: number;
-    prev_closing_price: number;
-    signed_change_rate: number;
-    signed_change_price: number;
-    acc_trade_price_24h: number;
-    acc_trade_volume_24h: number;
-    high_price: number;
-    low_price: number;
-    lowest_52_week_price: number;
-    highest_52_week_price: number;
-}
-
 /** 업비트 REST API 전체 KRW 마켓 현재가 조회
  * @description 모든 KRW 종목의 현재가 정보를 한 번에 가져와 초기 데이터로 활용
  * @param markets KRW 종목 목록 (getMarkets 결과)
@@ -36,13 +21,11 @@ export async function getAllTickers(markets: IUpbitMarket[]): Promise<Record<str
 
         console.log('📊 전체 KRW 마켓 현재가 요청: ', marketCodes.length);
 
-        const response = await upbit.ticker(marketCodes) as unknown as IUpbitRestTicker[];
+        const response = await upbit.restTicker(marketCodes);
 
-        const tickers: Record<string, ITicker> = {};
-
-        response.forEach((restTicker: IUpbitRestTicker) => {
+        const tickers: Record<string, ITicker> = response.reduce((acc, restTicker) => {
             if (restTicker?.market) {
-                tickers[restTicker.market] = {
+                acc[restTicker.market] = {
                     market: restTicker.market,
                     trade_price: restTicker.trade_price || 0,
                     prev_closing_price: restTicker.prev_closing_price || 0,
@@ -56,7 +39,8 @@ export async function getAllTickers(markets: IUpbitMarket[]): Promise<Record<str
                     highest_52_week_price: restTicker.highest_52_week_price || 0,
                 };
             }
-        });
+            return acc;
+        }, {} as Record<string, ITicker>);
 
         console.log('✅ 전체 현재가 데이터 로드 완료:', {
             응답수: response.length,

--- a/frontend/hooks/upbit/useInitialTickers.ts
+++ b/frontend/hooks/upbit/useInitialTickers.ts
@@ -13,7 +13,7 @@ export function useInitialTickers() {
     const { markets } = useMarkets();
 
     const { data: initialTickers, isLoading, error, isError } = useQuery({
-        queryKey: tickerQuery.byMarketsCount(markets?.length || 0),
+        queryKey: tickerQuery.all(),
         queryFn: () => getAllTickers(markets || []),
         enabled: !!markets && markets.length > 0,
         refetchOnWindowFocus: false,

--- a/frontend/lib/api/upbit.ts
+++ b/frontend/lib/api/upbit.ts
@@ -1,12 +1,13 @@
 import { apiClient } from '@/lib/api/apiClient';
 import { IUpbitMarket } from '@/types/upbit/market';
-import { IUpbitTicker } from '@/types/upbit/ticker';
+import { IUpbitRestTicker, IUpbitTicker } from '@/types/upbit/ticker';
 import { IUpbitMinuteCandle, IUpbitDayCandle, IUpbitWeekCandle, IUpbitMonthCandle } from '@/types/upbit/candle';
 
 /**
  * 업비트 REST API 팩토리 클래스
  * @function markets 거래 가능한 전체 종목 코드 목록
- * @function ticker 해당 마켓 코드(복수 가능) 현재가 정보
+ * @function ticker 해당 마켓 코드(복수 가능) 현재가 정보 (WebSocket)
+ * @function restTicker 해당 마켓 코드(복수 가능) 현재가 정보 (REST API)
  * @function candleMinutes 분봉
  * @function candleDays 일봉
  * @function candleWeeks 주봉 
@@ -26,6 +27,19 @@ export default class Upbit {
      * @param markets 전체 종목 목록 (단일 종목 또는 여러 종목)
      */
     async ticker(markets: string | string[]): Promise<IUpbitTicker | IUpbitTicker[]> {
+        try {
+            const codesParam = Array.isArray(markets) ? markets.join(',') : markets;
+            return await apiClient(`${process.env.NEXT_PUBLIC_UPBIT_API_URL}/ticker?markets=${codesParam}`, undefined, 'external');
+        } catch (error) {
+            console.error('현재가 다운로드 에러:', error);
+            throw error;
+        }
+    }
+
+    /**
+    * @param markets 전체 종목 목록 (단일 종목 또는 여러 종목)
+    */
+    async restTicker(markets: string | string[]): Promise<IUpbitRestTicker[]> {
         try {
             const codesParam = Array.isArray(markets) ? markets.join(',') : markets;
             return await apiClient(`${process.env.NEXT_PUBLIC_UPBIT_API_URL}/ticker?markets=${codesParam}`, undefined, 'external');

--- a/frontend/queries/upbit/ticker.query.ts
+++ b/frontend/queries/upbit/ticker.query.ts
@@ -2,9 +2,6 @@ export const tickerQuery = {
     /** 전체 초기 현재가 데이터 쿼리 키 */
     all: () => ['initial-tickers'] as const,
 
-    /** 특정 마켓 수에 따른 초기 현재가 데이터 쿼리 키 */
-    byMarketsCount: (count: number) => ['initial-tickers', count] as const,
-
     /** 특정 마켓들의 현재가 데이터 쿼리 키 */
     byMarkets: (markets: string[]) => ['initial-tickers', markets] as const,
 } as const;

--- a/frontend/types/upbit/ticker.ts
+++ b/frontend/types/upbit/ticker.ts
@@ -38,6 +38,23 @@ export interface IUpbitTicker {
     stream_type: string;
 }
 
+/** 업비트 종목 단위 현재가 정보(티커) Response
+ * @description REST API
+ */
+export interface IUpbitRestTicker {
+    market: string;
+    trade_price: number;
+    prev_closing_price: number;
+    signed_change_rate: number;
+    signed_change_price: number;
+    acc_trade_price_24h: number;
+    acc_trade_volume_24h: number;
+    high_price: number;
+    low_price: number;
+    lowest_52_week_price: number;
+    highest_52_week_price: number;
+}
+
 /**
  * 응답 중에서 실제로 사용하는 현재가 인터페이스
  * @description useTickerSocket, TickerProvider 에서 사용


### PR DESCRIPTION
## 📌  타입 리팩토링
- `getAllTickers.ts`의 const response = await upbit.ticker(marketCodes) as unknown as IUpbitRestTicker[]는 강제 타입 캐스팅이라 기술 부채 가능성
- 타입을 @/types/upbit/ticker.ts로 분리하고, @/lib/api/upbit.ts에 restTickers를 추가 생성하여 타입 캐스팅 대신 직접적 명시 방식으로 개선

## 📌 메서드 리팩토링
- `getAllTickers.ts`의 응답 배열을 레코드 객체로 변환하는 데 사용된 forEach를 reduce로 대체하여 가독성 향상

## 📌 쿼리키 리팩토링
- tickerQuery.byMarketsCount(markets?.length || 0)를 사용하는 것은 마켓 목록이 변경되었지만 총 개수는 동일할 경우 오래된 데이터를 제공할 가능성이 있음
- tickerQuery.all()로 코드를 수정하여 잠재 캐싱을 방지함