### PR TITLE
[refactor] TickerProvider, MarketDetailCard 객체 생성 메모이제이션 적용, 웹소켓에 500ms 쓰로틀링 적용

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,11 @@
 - test123@example.com
 - 123567as#
 
+<br>
+
 ### 접속 링크
 
-https://www.ezbit.vercel.app<br><br>
+https://www.ezbit.vercel.app/<br><br>
 
 ## 🎧 앱 다운로드 및 실행
 
@@ -128,7 +130,7 @@ npm run dev
 
 ### 🔥 실시간 거래소
 
-<img width="600" height="440" src="https://github.com/user-attachments/assets/888a63cf-b896-4632-bd8b-f2dd282b8f1e" />
+<img width="600" height="440" src="https://github.com/user-attachments/assets/888a63cf-b896-4632-bd8b-f2dd282b8f1e" /><br>
 
 **업비트 WebSocket**으로 실시간 현재가, 호가, 체결 내역 데이터를 제공합니다.<br>
 **Highcharts**의 캔들스틱 차트로 다양한 분봉 차트를 제공합니다.<br>
@@ -177,7 +179,7 @@ npm run dev
 EZBIT은 React Query로 데이터 페칭과 동시에 캐싱하여 서버 상태로 동기화하는 것이 메인입니다.<br>
 또한, 클라이언트에서 UI를 위해 따로 관리해야 할 전역 상태가 거의 없습니다.<br>
 따라서 Context API만으로 AuthProvider, TickerProvider를 구현하고<br>
-우산 패턴을 적용하여 적절한 범위를 제한하여 클라이언트 상태를 관리하고 있습니다.<br><br>
+우산 패턴을 적용하여 적절한 범위를 제한하여 클라이언트 상태를 관리하고 있습니다.<br>
 
 ### 디렉토리 구조: Feature Based
 
@@ -411,7 +413,6 @@ export const askSchema = z.object({
 ```
 
 <br>
-
 zod의 메서드 체이닝으로 직관적이고 효율적인 유효성 검증 로직을 구현했습니다.<br>
 React Hook Form의 useForm과 함께 조합하여 폼의 상태 관리와 유효성 검증, 에러 핸들링까지 담당합니다.<br>
 

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -99,7 +99,7 @@ const Header = () => {
 
 const Marquee = () => {
   return (
-    <section className="relative w-full flex items-center overflow-hidden [mask-image:_linear-gradient(to_right,transparent_0,_black_64px,_black_calc(100%-64px),transparent_100%)] sm:[mask-image:_linear-gradient(to_right,transparent_0,_black_128px,_black_calc(100%-200px),transparent_100%)]">
+    <section className="relative w-full bg-white flex items-center overflow-hidden [mask-image:_linear-gradient(to_right,transparent_0,_black_64px,_black_calc(100%-64px),transparent_100%)] sm:[mask-image:_linear-gradient(to_right,transparent_0,_black_128px,_black_calc(100%-200px),transparent_100%)]">
       <div className="pt-2 sm:pt-4 flex gap-2 sm:gap-4 flex-shrink-0 animate-marquee whitespace-nowrap">
         {LOGO_IMGS.map((logo, i) => (
           <Image
@@ -128,17 +128,43 @@ const Marquee = () => {
   );
 };
 
-const Introduce = () => {
+const IntroduceRealtimeExchange = () => {
+  return (
+    <section className='w-full bg-white'>
+      <div className="contents-container py-12 sm:py-16 md:py-20 px-4 lg:px-0 flex flex-col md:flex-row items-center gap-6 sm:gap-8 md:gap-10">
+        {/* 좌측 */}
+        <div className='w-100 h-80 flex justify-center rounded-lg shadow-lg'>
+          <Image
+            src="https://res.cloudinary.com/dbvzbdffi/image/upload/v1756444851/exchange_page_y6ql3f.avif"
+            alt="배경 이미지"
+            priority={true}
+            quality={100}
+            width={500}
+            height={500}
+            className="rounded-lg"
+          />
+        </div>
+        {/* 우측 */}
+        <div className='flex-1 flex flex-col items-end gap-4 justify-end'>
+          <p className="text-xl sm:text-2xl md:text-3xl lg:text-4xl font-bold text-right">실시간 거래소</p>
+          <span className="text-right text-sm sm:text-base md:text-lg lg:text-xl text-subtitle font-bold">실시간으로 업데이트 정보로 실감나는 투자 환경을 경험하실 수 있습니다</span>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+const IntroducePilot = () => {
   return (
     <section className="contents-container pt-12 sm:pt-16 md:pt-20 px-4 lg:px-0 flex flex-col md:flex-row items-center gap-6 sm:gap-8 md:gap-10">
       <div className="flex-1 flex flex-col gap-4 sm:gap-6">
         <div className="flex flex-col gap-1 sm:gap-2">
-          <h2 className="font-bold text-xl sm:text-2xl md:text-3xl lg:text-4xl text-center md:text-left">마음에 드는 옵션을 골라</h2>
-          <h2 className="font-bold text-xl sm:text-2xl md:text-3xl lg:text-4xl text-center md:text-left">나만의 포트폴리오를 구성하세요</h2>
+          <h2 className="font-bold text-xl sm:text-2xl md:text-3xl lg:text-4xl text-center md:text-left">마음에 드는 옵션을 골라보세요</h2>
+          <h2 className="font-bold text-xl sm:text-2xl md:text-3xl lg:text-4xl text-center md:text-left">파일럿이 매수 리스트를 만들어드려요</h2>
         </div>
         <p className="flex flex-col sm:flex-row gap-1 text-subtitle text-sm sm:text-base md:text-lg text-center md:text-left">
           <span className="font-bold">번거롭고 어려운 투자라고 생각하지 마세요!</span>
-          <span className="font-bold">옵션을 선택하고 바로 포트폴리오를 만들어보세요</span>
+          <span className="font-bold">딸깍하면 포트폴리오 완성!</span>
         </p>
       </div>
     </section>
@@ -169,11 +195,10 @@ export default function Home() {
       <Navbar />
       <Header />
       <Marquee />
-      <Introduce />
+      <IntroduceRealtimeExchange />
+      <IntroducePilot />
       <section className="contents-container py-8 sm:py-10 md:py-12 px-4 lg:px-0 flex flex-col md:flex-row gap-4 sm:gap-6">
-        {PORTFOLIO_OPTIONS.map((option, idx) => (
-          <PortfolioCard key={idx} {...option} />
-        ))}
+        {PORTFOLIO_OPTIONS.map((option, idx) => (<PortfolioCard key={idx} {...option} />))}
       </section>
       <Footer />
     </main>

--- a/frontend/components/exchange/MarketDetailCard.tsx
+++ b/frontend/components/exchange/MarketDetailCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useContext } from 'react';
+import { useContext, useMemo, memo } from 'react';
 import { TickerContext } from '@/providers/TickerProvider';
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/shadcn-ui/card";
 
@@ -20,7 +20,7 @@ const SUB_INDICATORS_COLUMN_STYLE = 'w-full basis-full flex flex-col justify-cen
  * @param {number} value 보조 지표 값
  * @param {string} valueStyle 보조 지표 값 스타일 코드
  */
-const SubIndicator = ({ label, value, valueStyle }: ISubIndicator) => {
+const SubIndicator = memo(({ label, value, valueStyle }: ISubIndicator) => {
     return (
         <div className='w-[13rem]'>
             <dl className="flex gap-4 justify-between">
@@ -34,18 +34,19 @@ const SubIndicator = ({ label, value, valueStyle }: ISubIndicator) => {
             <div className="w-full h-[0.05rem] bg-gray-300" />
         </div>
     );
-};
+});
+
+SubIndicator.displayName = 'SubIndicator';
 
 export default function MarketDetailCard() {
     const { currentTicker, selectedMarket, krwNames } = useContext(TickerContext);
 
     const krwName = krwNames[selectedMarket];
 
-    const color = currentTicker?.signed_change_rate < 0
-        ? 'text-negative'
-        : currentTicker?.signed_change_rate > 0
-            ? 'text-positive'
-            : 'text-black';
+    const color = useMemo(() => {
+        if (!currentTicker?.signed_change_rate) return 'text-black';
+        return currentTicker.signed_change_rate < 0 ? 'text-negative' : 'text-positive';
+    }, [currentTicker?.signed_change_rate]);
 
     return (
         <Card

--- a/frontend/hooks/socket/useOrderbookSocket.ts
+++ b/frontend/hooks/socket/useOrderbookSocket.ts
@@ -20,9 +20,9 @@ export function useOrderbookSocket(market: string) {
         // 데이터 검증 및 현재 마켓 확인
         if (!data?.code || data.code !== currentMarketRef.current) return;
 
-        // 스로틀링: 100ms 내 중복 업데이트 방지
+        // 스로틀링: 500ms 내 중복 업데이트 방지 (성능 최적화)
         const currentTime = data.timestamp || Date.now();
-        if (currentTime - lastUpdateTimeRef.current < 100) return;
+        if (currentTime - lastUpdateTimeRef.current < 500) return;
 
         lastUpdateTimeRef.current = currentTime;
 

--- a/frontend/hooks/socket/useTickerSocket.ts
+++ b/frontend/hooks/socket/useTickerSocket.ts
@@ -21,11 +21,44 @@ export function useTickerSocket({ markets, setTickers, initialTickers }: IConnec
     const subscribedMarketsRef = useRef<Set<string>>(new Set());
     const setTickersRef = useRef(setTickers);
 
+    // 쓰로틀링을 위한 refs
+    const throttleTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const pendingUpdatesRef = useRef<Record<string, ITicker>>({});
+
     useEffect(() => {
         setTickersRef.current = setTickers;
     }, [setTickers]);
 
-    // 현재가 데이터 업데이트 함수
+    // 쓰로틀링된 업데이트 실행 함수
+    const flushPendingUpdates = useCallback(() => {
+        const updates = { ...pendingUpdatesRef.current };
+        if (Object.keys(updates).length === 0) return;
+
+        pendingUpdatesRef.current = {};
+
+        setTickersRef.current(prev => {
+            const nextState = { ...prev };
+            let hasChanges = false;
+
+            for (const [market, newTicker] of Object.entries(updates)) {
+                const prevTicker = prev[market];
+                // 더 상세한 비교로 불필요한 업데이트 방지
+                if (!prevTicker ||
+                    prevTicker.trade_price !== newTicker.trade_price ||
+                    prevTicker.signed_change_rate !== newTicker.signed_change_rate ||
+                    prevTicker.acc_trade_price_24h !== newTicker.acc_trade_price_24h ||
+                    prevTicker.high_price !== newTicker.high_price ||
+                    prevTicker.low_price !== newTicker.low_price) {
+                    nextState[market] = newTicker;
+                    hasChanges = true;
+                }
+            }
+
+            return hasChanges ? nextState : prev;
+        });
+    }, []);
+
+    // 500ms 쓰로틀링된 현재가 데이터 업데이트 함수
     const updateTickers = useCallback((tickerData: IUpbitTicker) => {
         if (!tickerData?.code) return;
 
@@ -43,22 +76,17 @@ export function useTickerSocket({ markets, setTickers, initialTickers }: IConnec
             highest_52_week_price: tickerData.highest_52_week_price,
         };
 
-        setTickersRef.current(prev => {
-            const prevTicker = prev[tickerData.code];
-            // 더 상세한 비교로 불필요한 업데이트 방지
-            if (prevTicker &&
-                prevTicker.trade_price === newTicker.trade_price &&
-                prevTicker.signed_change_rate === newTicker.signed_change_rate &&
-                prevTicker.acc_trade_price_24h === newTicker.acc_trade_price_24h &&
-                prevTicker.high_price === newTicker.high_price &&
-                prevTicker.low_price === newTicker.low_price) {
-                return prev;
-            }
+        // 펜딩 업데이트에 추가 (최신 데이터로 덮어쓰기)
+        pendingUpdatesRef.current[tickerData.code] = newTicker;
 
-            // 새 객체 생성 최적화
-            return { ...prev, [tickerData.code]: newTicker };
-        });
-    }, []);
+        // 쓰로틀링: 500ms마다 한 번씩만 실행
+        if (throttleTimeoutRef.current) return;
+
+        throttleTimeoutRef.current = setTimeout(() => {
+            flushPendingUpdates();
+            throttleTimeoutRef.current = null;
+        }, 500);
+    }, [flushPendingUpdates]);
 
     // 마켓 구독 관리
     useEffect(() => {

--- a/frontend/hooks/socket/useTradeSocket.ts
+++ b/frontend/hooks/socket/useTradeSocket.ts
@@ -5,6 +5,7 @@ import { useSocket } from '@/hooks/socket/useSocket';
 import { IUpbitTrade } from '@/types/upbit/trade';
 
 const MAX_TRADES_COUNT = 50; // 메모리 사용량 줄임
+const THROTTLE_MS = 500; // 쓰로틀링 간격
 
 /** 실시간 거래내역 데이터 구독 훅
  * @description 업비트 WebSocket에서 실시간 거래 체결 데이터를 구독하고 순환 버퍼로 관리하는 최적화된 훅
@@ -17,24 +18,46 @@ export function useTradeSocket(market: string) {
 
     const currentMarketRef = useRef<string>('');
     const tradesBufferRef = useRef<IUpbitTrade[]>([]);
+    const pendingTradesRef = useRef<IUpbitTrade[]>([]);
+    const throttleTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-    // 거래내역 업데이트 함수 (스로틀링 적용)
+    // 쓰로틀링된 업데이트 실행 함수
+    const flushPendingTrades = useCallback(() => {
+        if (pendingTradesRef.current.length === 0) return;
+
+        // 중복 제거 및 최신 순 정렬
+        const uniqueTrades = pendingTradesRef.current
+            .filter((trade, index, arr) =>
+                arr.findIndex(t => t.sequential_id === trade.sequential_id) === index
+            )
+            .sort((a, b) => b.timestamp - a.timestamp);
+
+        // 기존 버퍼와 병합
+        const mergedTrades = [...uniqueTrades, ...tradesBufferRef.current]
+            .slice(0, MAX_TRADES_COUNT);
+
+        tradesBufferRef.current = mergedTrades;
+        pendingTradesRef.current = [];
+
+        setTrades([...mergedTrades]);
+    }, []);
+
+    // 거래내역 업데이트 함수 (500ms 쓰로틀링 적용)
     const updateTrade = useCallback((data: IUpbitTrade) => {
         // 데이터 검증 및 현재 마켓 확인
         if (!data?.code || data.code !== currentMarketRef.current) return;
 
-        // 중복 데이터 체크 (sequential_id 기준으로 간소화)
-        if (tradesBufferRef.current.length > 0 && 
-            tradesBufferRef.current[0].sequential_id === data.sequential_id) {
-            return;
-        }
+        // 펜딩 배열에 추가
+        pendingTradesRef.current.push(data);
 
-        // 효율적인 배열 업데이트 (unshift보다 빠름)
-        tradesBufferRef.current = [data, ...tradesBufferRef.current.slice(0, MAX_TRADES_COUNT - 1)];
+        // 쓰로틀링: 500ms마다 한 번씩만 실행
+        if (throttleTimeoutRef.current) return;
 
-        // 상태 업데이트 (배치 업데이트)
-        setTrades([...tradesBufferRef.current]);
-    }, []);
+        throttleTimeoutRef.current = setTimeout(() => {
+            flushPendingTrades();
+            throttleTimeoutRef.current = null;
+        }, THROTTLE_MS);
+    }, [flushPendingTrades]);
 
     // 마켓 변경 시 거래내역 초기화 및 구독 관리
     useEffect(() => {
@@ -50,6 +73,11 @@ export function useTradeSocket(market: string) {
 
         // 거래내역 초기화
         tradesBufferRef.current = [];
+        pendingTradesRef.current = [];
+        if (throttleTimeoutRef.current) {
+            clearTimeout(throttleTimeoutRef.current);
+            throttleTimeoutRef.current = null;
+        }
         setTrades([]);
 
         // 새 마켓 구독

--- a/frontend/providers/TickerProvider.tsx
+++ b/frontend/providers/TickerProvider.tsx
@@ -123,8 +123,13 @@ export function TickerProvider({ children }: { children: React.ReactNode }) {
     }, [selectedMarket]);
 
     const currentTicker = useMemo(() => {
-        return tickers[selectedMarket] || EMPTY_TICKER;
-    }, [tickers, selectedMarket]);
+        const ticker = tickers[selectedMarket];
+        if (!ticker) return EMPTY_TICKER;
+        
+        // 실제로 값이 변경되었을 때만 새 객체 반환
+        if (ticker === EMPTY_TICKER) return EMPTY_TICKER;
+        return ticker;
+    }, [tickers[selectedMarket], selectedMarket]);
 
     const optimizedSetTickers = useCallback<SetTickerState>((tickersOrUpdater) => {
         if (typeof tickersOrUpdater === 'function') {


### PR DESCRIPTION
## 📌 거래소 페이지 성능 저하 개선
- 실시간 업데이트로 인해 거래소 페이지의 성능 저하 발생(lighthouse 기준 44점)
- TickerProvider에서 실제로 티커가 변해야만 새로 반환하게 함
- MarketDetailCard의 SubIndicator에 memo적용
- 거래내역 웹소켓 연결 훅에 거래량 제한, 쓰로틀링 적용